### PR TITLE
chore: remove unused files and sync lockfile (fixes #10)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,8 @@
       "name": "myapp",
       "version": "0.0.0",
       "dependencies": {
-        "clsx": "^2.1.1",
         "react": "^19.2.4",
-        "react-dom": "^19.2.4",
-        "tailwind-merge": "^3.5.0"
+        "react-dom": "^19.2.4"
       },
       "devDependencies": {
         "@chromatic-com/storybook": "^5.0.1",
@@ -5345,15 +5343,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/clsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -11898,16 +11887,6 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/tailwind-merge": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
-      "integrity": "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/dcastil"
-      }
     },
     "node_modules/timer-node": {
       "version": "5.0.9",

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,0 @@
-import { type ClassValue, clsx } from 'clsx';
-import { twMerge } from 'tailwind-merge';
-
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
-}

--- a/vitest.shims.d.ts
+++ b/vitest.shims.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="@vitest/browser-playwright" />


### PR DESCRIPTION
This PR completes the dead code cleanup by removing 'src/lib/utils.ts' and 'vitest.shims.d.ts' which were identified as unused by Knip. It also synchronizes the 'package-lock.json' after recent script updates.