### PR TITLE
chore: simplify and fix nested ARCHITECTURE.md check in doc hook

### DIFF
--- a/.gemini/hooks/remind-docs.sh
+++ b/.gemini/hooks/remind-docs.sh
@@ -3,24 +3,23 @@
 # 1. Read the input from Gemini CLI
 INPUT=$(cat)
 
-# 2. Extract the AI's response text and check for keywords
-# We use 'tr' to make it case-insensitive
+# 2. Extract the AI's response text
 RESPONSE=$(echo "$INPUT" | grep -oP '"prompt_response":\s*"\K[^"]+')
 EXPLANATION_GIVEN=$(echo "$RESPONSE" | tr '[:upper:]' '[:lower:]' | grep -E "no update needed|docs are current|no changes required")
 
 # 3. Get git status
 MODIFIED=$(git status --porcelain)
 CODE_CHANGED=$(echo "$MODIFIED" | grep -E "\.(ts|tsx|js|jsx)$")
-DOCS_CHANGED=$(echo "$MODIFIED" | grep -E "(CHANGELOG\.md|GEMINI\.md|architecture\.md)$")
+
+# Catch any of the docs anywhere in the tree, case-insensitive for ARCHITECTURE.md
+DOCS_CHANGED=$(echo "$MODIFIED" | grep -Ei "(CHANGELOG\.md|GEMINI\.md|ARCHITECTURE\.md)$")
 
 # 4. Decision Logic
 if [ -n "$CODE_CHANGED" ] && [ -z "$DOCS_CHANGED" ] && [ -z "$EXPLANATION_GIVEN" ]; then
-    # BLOCK if code changed, no docs changed, and no explanation was typed
     echo "{"
     echo "  \"decision\": \"block\","
-    echo "  \"reason\": \"You updated code but skipped documentation. Update architecture.md, CHANGELOG.md, or GEMINI.md. If no update is needed, you MUST state 'no update needed' to proceed.\""
+    echo "  \"reason\": \"NUDGE: You updated code but no documentation (CHANGELOG, GEMINI, or any ARCHITECTURE.md) was modified. Please update them to reflect your changes, or state 'no update needed' if the changes are trivial.\""
     echo "}"
 else
-    # ALLOW if docs were updated OR if the AI gave the 'magic' explanation
     echo "{\"decision\": \"allow\"}"
 fi


### PR DESCRIPTION
This PR simplifies the 'remind-docs.sh' hook to correctly detect any modified 'ARCHITECTURE.md' file throughout the project's nested directory structure. It also ensures 'CHANGELOG.md' and 'GEMINI.md' are checked, and the 'no update needed' bypass remains functional.