### PR TITLE
chore: add semantic protocol pointer to doc nudge hook

### DIFF
--- a/.gemini/hooks/remind-docs.sh
+++ b/.gemini/hooks/remind-docs.sh
@@ -14,11 +14,13 @@ CODE_CHANGED=$(echo "$MODIFIED" | grep -E "\.(ts|tsx|js|jsx)$")
 # Catch any of the docs anywhere in the tree, case-insensitive for ARCHITECTURE.md
 DOCS_CHANGED=$(echo "$MODIFIED" | grep -Ei "(CHANGELOG\.md|GEMINI\.md|ARCHITECTURE\.md)$")
 
+REASON="NUDGE: Code changed without doc updates. Re-verify the 'Done' Definition, 'Task Gate' Protocol, and Architecture Sync in GEMINI.md, ARCHITECTURE.md, and CHANGELOG.md before finishing. If no update is needed, state 'no update needed' to proceed."
+
 # 4. Decision Logic
 if [ -n "$CODE_CHANGED" ] && [ -z "$DOCS_CHANGED" ] && [ -z "$EXPLANATION_GIVEN" ]; then
     echo "{"
     echo "  \"decision\": \"block\","
-    echo "  \"reason\": \"NUDGE: You updated code but no documentation (CHANGELOG, GEMINI, or any ARCHITECTURE.md) was modified. Please update them to reflect your changes, or state 'no update needed' if the changes are trivial.\""
+    echo "  \"reason\": \"$REASON\""
     echo "}"
 else
     echo "{\"decision\": \"allow\"}"


### PR DESCRIPTION
This PR updates the 'remind-docs.sh' hook to include a semantic pointer to GEMINI.md, ARCHITECTURE.md, and CHANGELOG.md, forcing the AI to re-verify the 'Done' Definition and 'Task Gate' Protocol before completing a task.